### PR TITLE
Adopt terms from Storage spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -172,18 +172,21 @@ Resource names starting with U+002D HYPHEN-MINUS (-) are reserved; requesting th
 ## Lock Managers ## {#lock-managers}
 <!-- ====================================================================== -->
 
-A [=/user agent=] has a <dfn>lock manager</dfn> for each [=/storage bucket=], which encapsulates the state of all [=lock-concept|locks=] and [=lock requests=] associated with a [=/storage bucket=].
+A <dfn>lock manager</dfn> encapsulates the state of [=lock-concept|locks=] and [=lock requests=]. Each [=/storage bucket=] includes one [=/lock manager=] through an associated [=/storage bottle=] for the Web Locks API.
 
 Note: Pages and workers ([=/agents=]) sharing a [=/storage bucket=] opened in the same user agent share a [=/lock manager=] even if they are in unrelated [=/browsing contexts=].
 
 <div algorithm>
 To <dfn>obtain a lock manager</dfn>, given an [=/environment settings object=] |environment|, run these steps:
 
-1. Let |bottle| be the result of [=/obtaining a local storage bottle map=] given |environment| and "`web-locks`".
-1. If |bottle| is failure, then return failure.
+1. Let |map| be the result of [=/obtaining a local storage bottle map=] given |environment| and "`web-locks`".
+1. If |map| is failure, then return failure.
+1. Let |bottle| be |map|'s associated [=/storage bottle=].
 1. Return |bottle|'s associated [=/lock manager=].
 
 </div>
+
+Issue: Refine the integration with [[Storage]] here, including how to get the lock manager properly from the given environment.
 
 
 <!-- ====================================================================== -->

--- a/index.bs
+++ b/index.bs
@@ -156,7 +156,7 @@ The [=task source=] for [=parallel queue/enqueue steps|steps enqueued=] below is
 A <dfn>resource name</dfn> is a [=JavaScript string=] chosen by the web application to represent an abstract resource.
 
 A resource name has no external meaning beyond the scheduling algorithm, but is global
-across [=/browsing contexts=] sharing a [=/storage bucket=]. Web applications are free to use any resource naming scheme.
+across [=/agents=] sharing a [=/storage bucket=]. Web applications are free to use any resource naming scheme.
 
 <aside class=example id=example-indexeddb-transactions>
 To mimic transaction locking over named stores within a named
@@ -172,7 +172,7 @@ Resource names starting with U+002D HYPHEN-MINUS (-) are reserved; requesting th
 ## Lock Managers ## {#lock-managers}
 <!-- ====================================================================== -->
 
-A [=/user agent=] has a <dfn>lock manager</dfn> for each [=/storage bottle=], which encapsulates the state of all [=lock-concept|locks=] and [=lock requests=] associated with a [=/storage bucket=].
+A [=/user agent=] has a <dfn>lock manager</dfn> for each [=/storage bucket=], which encapsulates the state of all [=lock-concept|locks=] and [=lock requests=] associated with a [=/storage bucket=].
 
 Note: Pages and workers ([=/agents=]) sharing a [=/storage bucket=] opened in the same user agent share a [=/lock manager=] even if they are in unrelated [=/browsing contexts=].
 

--- a/index.bs
+++ b/index.bs
@@ -28,7 +28,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
             text: agent cluster; url: integration-with-the-javascript-agent-cluster-formalism
 spec: storage; urlPrefix: https://storage.spec.whatwg.org/
     type: dfn
-        text: storage shelf; url: storage-shelf
+        text: storage bucket; url: storage-bucket
+        text: storage bottle; url: storage-bottle
 </pre>
 
 <style>
@@ -80,7 +81,7 @@ The API provides optional functionality that may be used as needed, including:
 * diagnostics to query the state of locks, and
 * an escape hatch to protect against deadlocks.
 
-Cooperative coordination takes place within the scope of same-origin [=/agents=]; this may span multiple [=/agent clusters=].
+Cooperative coordination takes place within the scope of [=/agents=] sharing a [=/storage bucket=]; this may span multiple [=/agent clusters=].
 
 <aside class=note>
 [=/Agents=] roughly correspond to windows (tabs), iframes, and workers. [=/Agent clusters=] correspond to independent processes in some user agent implementations.
@@ -155,7 +156,7 @@ The [=task source=] for [=parallel queue/enqueue steps|steps enqueued=] below is
 A <dfn>resource name</dfn> is a [=JavaScript string=] chosen by the web application to represent an abstract resource.
 
 A resource name has no external meaning beyond the scheduling algorithm, but is global
-across [=/browsing contexts=] within an [=/origin=]. Web applications are free to use any resource naming scheme.
+across [=/browsing contexts=] sharing a [=/storage bucket=]. Web applications are free to use any resource naming scheme.
 
 <aside class=example id=example-indexeddb-transactions>
 To mimic transaction locking over named stores within a named
@@ -171,31 +172,18 @@ Resource names starting with U+002D HYPHEN-MINUS (-) are reserved; requesting th
 ## Lock Managers ## {#lock-managers}
 <!-- ====================================================================== -->
 
-A [=/user agent=] has a <dfn>lock manager</dfn> for each [=/origin=], which encapsulates the state of all [=lock-concept|locks=] and [=lock requests=] for that origin.
+A [=/user agent=] has a <dfn>lock manager</dfn> for each [=/storage bottle=], which encapsulates the state of all [=lock-concept|locks=] and [=lock requests=] associated with a [=/storage bucket=].
 
-Note: Pages and workers ([=/agents=]) on a single [=/origin=] opened in the same user agent share a lock manager even if they are in unrelated [=/browsing contexts=].
+Note: Pages and workers ([=/agents=]) sharing a [=/storage bucket=] opened in the same user agent share a [=/lock manager=] even if they are in unrelated [=/browsing contexts=].
 
 <div algorithm>
 To <dfn>obtain a lock manager</dfn>, given an [=/environment settings object=] |environment|, run these steps:
 
-1. Let |origin| be |environment|'s [=/origin=].
-1. If |origin| is an [=/opaque origin=], then return failure.
-1. Return |origin|'s associated [=/lock manager=].
+1. Let |bottle| be the result of [=/obtaining a local storage bottle map=] given |environment| and "`web-locks`".
+1. If |bottle| is failure, then return failure.
+1. Return |bottle|'s associated [=/lock manager=].
 
 </div>
-
-<aside class=note>
-
-    There is an equivalence between the following:
-
-    * Agents that share a [=lock manager=].
-    * Agents that share a [=/storage shelf=], i.e. a per-origin [=localStorage|local storage area=] [[HTML]], set of [[IndexedDB-2#database-construct|databases]] [[IndexedDB-2]], or [[Service-Workers#cache-objects|caches]] [[Service-Workers]].
-
-</aside>
-
-<aside class=issue>
-Migrate this definition to [[HTML]] or [[Storage]] so it can be referenced by other standards.
-</aside>
 
 
 <!-- ====================================================================== -->


### PR DESCRIPTION
Nominally, replace "origin" with "storage key". But practically speaking:

* Associate a lock manager with a storage bottle
* Acquire a bottle from an environment, a manager from the bottle, and associate locks/requests with a manager

Some references to "storage bucket" are retained in prose where it seems to add value and is more correct than "origin".

Fixes #74


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-locks/pull/75.html" title="Last updated on Nov 12, 2021, 10:01 PM UTC (512988a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-locks/75/0d1d24e...512988a.html" title="Last updated on Nov 12, 2021, 10:01 PM UTC (512988a)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-locks/pull/75.html" title="Last updated on Nov 29, 2022, 9:02 PM UTC (43ce2e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-locks/75/d99a991...43ce2e3.html" title="Last updated on Nov 29, 2022, 9:02 PM UTC (43ce2e3)">Diff</a>