### PR TITLE
Use `[=AbortSignal/abort reason=]`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -503,7 +503,7 @@ The <dfn method for=LockManager>request(|name|, |callback|)</dfn> and
 1. If both |options|' `steal` dictionary member and |options|' `ifAvailable` dictionary member are true, then return [=a promise rejected with=] a "{{NotSupportedError}}" {{DOMException}}.
 1. If |options|' `steal` dictionary member is true and |options|' `mode` dictionary member is not "{{exclusive}}", then return [=a promise rejected with=] a "{{NotSupportedError}}" {{DOMException}}.
 1. If |options|' `signal` dictionary member is present, and either of |options|' `steal` dictionary member or |options|' `ifAvailable` dictionary member is true, then return [=a promise rejected with=] a "{{NotSupportedError}}" {{DOMException}}.
-1. If |options|' `signal` dictionary member is present and its [=AbortSignal/aborted flag=] is set, then return [=a promise rejected with=] an "{{AbortError}}" {{DOMException}.
+1. If |options|' `signal` dictionary member is present and is [=AbortSignal/aborted=], then return [=a promise rejected with=] an "{{AbortError}}" {{DOMException}.
 1. Let |promise| be [=a new promise=].
 1. [=Request a lock=] with |promise|, the current [=/agent=], |environment|'s [=environment/id=], |origin|, |callback|, |name|, |options|' `mode` dictionary member, |options|' `ifAvailable` dictionary member, |options|' `steal` dictionary member, and |options|' `signal` dictionary member.
 1. Return |promise|.
@@ -684,7 +684,7 @@ To <dfn>process the lock request queue</dfn> |queue|:
     1. [=set/Append=] |lock| to |origin|'s [=held lock set=].
     1. [=Enqueue the following steps=] on |callback|'s [=relevant settings object=]'s [=responsible event loop=]:
         1. If |signal| is present, then run these steps:
-            1. If |signal|'s [=AbortSignal/aborted flag=] is set, then run these steps:
+            1. If |signal| is [=AbortSignal/aborted=], then run these steps:
                 1. [=Enqueue the following step=] to the [=lock task queue=]:
                     1. [=Release the lock=] |lock|.
                 1. Return.

--- a/index.bs
+++ b/index.bs
@@ -594,7 +594,7 @@ The <dfn attribute for=Lock>mode</dfn> getter's steps are to return the associat
 To <dfn>request a lock</dfn> with |promise|, |agent|, |clientId|, |origin|, |callback|, |name|, |mode|, |ifAvailable|, |steal|, and |signal|:
 
 1. Let |request| be a new [=lock request=] (|agent|, |clientId|, |origin|, |name|, |mode|, |callback|, |promise|, |signal|).
-1. If |signal| is present, then [=AbortSignal/add=] the algorithm [=signal to abort the request=] |request| to |signal|.
+1. If |signal| is present, then [=AbortSignal/add=] the algorithm [=signal to abort the request=] |request| with |signal| to |signal|.
 1. [=Enqueue the following steps=] to the [=lock task queue=]:
     1. Let |queueMap| be |origin|'s [=lock request queue map=].
     1. Let |queue| be the result of [=/getting the lock request queue=] from |queueMap| for |name|.
@@ -651,10 +651,10 @@ To <dfn>abort the request</dfn> |request|:
 </div>
 
 <div algorithm>
-To <dfn>signal to abort the request</dfn> |request|:
+To <dfn>signal to abort the request</dfn> |request| with |signal|:
 
 1. [=enqueue the following steps|Enqueue the steps=] to [=abort the request=] |request| to the [=lock task queue=].
-1. [=Reject=] |request|'s [=lock request/promise=] with an "{{AbortError}}" {{DOMException}}.
+1. [=Reject=] |request|'s [=lock request/promise=] with |signal|'s [=AbortSignal/abort reason=].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -503,7 +503,7 @@ The <dfn method for=LockManager>request(|name|, |callback|)</dfn> and
 1. If both |options|' `steal` dictionary member and |options|' `ifAvailable` dictionary member are true, then return [=a promise rejected with=] a "{{NotSupportedError}}" {{DOMException}}.
 1. If |options|' `steal` dictionary member is true and |options|' `mode` dictionary member is not "{{exclusive}}", then return [=a promise rejected with=] a "{{NotSupportedError}}" {{DOMException}}.
 1. If |options|' `signal` dictionary member is present, and either of |options|' `steal` dictionary member or |options|' `ifAvailable` dictionary member is true, then return [=a promise rejected with=] a "{{NotSupportedError}}" {{DOMException}}.
-1. If |options|' `signal` dictionary member is present and is [=AbortSignal/aborted=], then return [=a promise rejected with=] an "{{AbortError}}" {{DOMException}.
+1. If |options|' `signal` dictionary member is present and is [=AbortSignal/aborted=], then return [=a promise rejected with=] |signal|'s [=AbortSignal/abort reason=].
 1. Let |promise| be [=a new promise=].
 1. [=Request a lock=] with |promise|, the current [=/agent=], |environment|'s [=environment/id=], |origin|, |callback|, |name|, |options|' `mode` dictionary member, |options|' `ifAvailable` dictionary member, |options|' `steal` dictionary member, and |options|' `signal` dictionary member.
 1. Return |promise|.


### PR DESCRIPTION
From https://github.com/whatwg/dom/issues/1030

cc @annevk

Will also modify relevant WPT tests soon.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/web-locks/pull/86.html" title="Last updated on Nov 12, 2021, 9:18 PM UTC (d4c4323)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-locks/86/0d1d24e...saschanaz:d4c4323.html" title="Last updated on Nov 12, 2021, 9:18 PM UTC (d4c4323)">Diff</a>