### PR TITLE
Set spec status as unofficial for now

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,7 +2,7 @@
 Title: Web Locks API
 Shortname: Web-Locks
 Abstract: This document defines a web platform API that allows script to asynchronously acquire a lock over a resource, hold it while work is performed, then release it. While held, no other script in the origin can acquire a lock over the same resource. This allows contexts (windows, workers) within a web application to coordinate the usage of resources.
-Status: ED
+Status: UD
 ED: https://w3c.github.io/web-locks/
 Level: 1
 Editor: Joshua Bell, Google Inc. https://google.com, jsbell@google.com


### PR DESCRIPTION
Per https://github.com/w3c/web-locks/pull/101#issuecomment-984312487.

I guess this can jump right to WD if Marcos can set the environment for us.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Dec 2, 2021, 11:52 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fweb-locks%2Fb4026322f208b836b46563a602579a8a97719dab%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
WARNING: Example needs ID:
&lt;div class="example">
        &lt;p>This is an example of an informative example.&lt;/p>
    &lt;/div>
FATAL ERROR: Found unmatched text macro [REPOSITORY]. Correct the macro, or escape it with a leading backslash.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/web-locks%23103.)._
</details>
