### PR TITLE
Editorial: Fix the logo image background in dark mode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -52,7 +52,7 @@ spec: storage; urlPrefix: https://storage.spec.whatwg.org/
 
 <img id="speclogo" src="logo-lock.svg" alt="logo" width="100" height="100">
 <style>
-#speclogo { height: 100px; width: 100px; }
+#speclogo { height: 100px; width: 100px; background-color: transparent; }
 main #speclogo { position: absolute; right: 20px; top: 30px; }
 .logo #speclogo { margin-top: 20px; }
 </style>


### PR DESCRIPTION
The webapps template makes image background colors white in dark mode;
this is not desired for the spec's logo image, so force its background
to transparent.

Before:
![image](https://user-images.githubusercontent.com/771547/144481777-0fbe59a1-2c29-4afe-aef7-ee70b72e4510.png)

After:
![image](https://user-images.githubusercontent.com/771547/144481811-92296975-67f4-4d68-988e-a969bd525217.png)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-locks/pull/104.html" title="Last updated on Dec 2, 2021, 6:32 PM UTC (28dd1f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-locks/104/eb3bc9d...28dd1f9.html" title="Last updated on Dec 2, 2021, 6:32 PM UTC (28dd1f9)">Diff</a>