### PR TITLE
update metadata

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,13 +1,15 @@
 <pre class=metadata>
 Title: Web Locks API
-Shortname: Web-Locks
+Shortname: web-locks
 Abstract: This document defines a web platform API that allows script to asynchronously acquire a lock over a resource, hold it while work is performed, then release it. While held, no other script in the origin can acquire a lock over the same resource. This allows contexts (windows, workers) within a web application to coordinate the usage of resources.
-Status: UD
+Status: ED
 ED: https://w3c.github.io/web-locks/
 Level: 1
-Editor: Joshua Bell, Google Inc. https://google.com, jsbell@google.com
+TR: https://www.w3.org/TR/web-locks/
+Editor: Joshua Bell, Google Inc. https://google.com, jsbell@google.com, w3cid 61302
 Editor: Kagami Rosylight, Mozilla https://www.mozilla.org/, krosylight@mozilla.com, w3cid 107856
 Group: webapps
+Repository: w3c/web-locks
 Test Suite: https://github.com/web-platform-tests/wpt/tree/master/web-locks
 Favicon: logo-lock.svg
 Complain About: accidental-2119 yes, missing-example-ids yes


### PR DESCRIPTION
Web Locks API will be published as FPWD by the WebApps WG soon -> https://www.w3.org/TR/2023/WD-web-locks-20230105/

Update the metadata for future versions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/siusin/web-locks/pull/113.html" title="Last updated on Jan 5, 2023, 8:55 AM UTC (85fa18f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-locks/113/ffddb56...siusin:85fa18f.html" title="Last updated on Jan 5, 2023, 8:55 AM UTC (85fa18f)">Diff</a>